### PR TITLE
fix: update pub-dates to new tagging

### DIFF
--- a/manuscripts/46294/manuscript.xml
+++ b/manuscripts/46294/manuscript.xml
@@ -265,7 +265,7 @@
                     <p>Department of Physiology, David Geffen School of Medicine, University of California, Los Angeles, Los Angeles, United States</p>
                 </fn>
             </author-notes>
-            <pub-date date-type="publication" publication-format="electronic">
+            <pub-date date-type="pub" publication-format="electronic">
                 <day>15</day>
                 <month>10</month>
                 <year>2019</year>

--- a/manuscripts/54296/elife-54296.xml
+++ b/manuscripts/54296/elife-54296.xml
@@ -100,7 +100,7 @@
           <country>United States</country>
         </aff>
       </contrib-group>
-      <pub-date date-type="publication" publication-format="electronic">
+      <pub-date date-type="pub" publication-format="electronic">
         <day>24</day>
         <month>01</month>
         <year>2020</year>


### PR DESCRIPTION
Old style `<pub-date date-type="publication">` changed to desired `<pub-date date-type="pub">`